### PR TITLE
Update sync-repo.sh

### DIFF
--- a/sync-repo.sh
+++ b/sync-repo.sh
@@ -1,15 +1,12 @@
 # This bash script uses git to synchronize changes between the local and remote GitHub repository.
 
-# TODO: Ask copilot chat to review the script and suggest improvements.
-
-
 git add .
 
 git commit -m "Updated"
 
-git pull origin main
+git pull 
 
-git push origin main
+git push 
 
 # Check if the push was successful
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
This pull request makes a small update to the `sync-repo.sh` script. The change removes hardcoded references to the `main` branch in `git pull` and `git push` commands, making the script more flexible for repositories using different default branch names.